### PR TITLE
Fix toolbar button assignment

### DIFF
--- a/www/PKNativeControls.js
+++ b/www/PKNativeControls.js
@@ -397,7 +397,7 @@
       self._buttons = buttons.map ( function (button) {
         return button._id;
       });
-      return self._owner.queueExec( self, "setButtons", self._rightButtons, self._handleSuccess, self._handleError  );
+      return self._owner.queueExec( self, "setButtons", self._buttons, self._handleSuccess, self._handleError  );
     };
     Object.defineProperty ( self, "buttons", { get: self.getButtons, set: self.setButtons, configurable: true } );
 


### PR DESCRIPTION
I saw what seems to be a wrong variable being passed into the Toolbar setButtons function - with my change I'm now seeing buttons show up. 
